### PR TITLE
Export DEC edge metadata for baseline stepper

### DIFF
--- a/LENR.ipynb
+++ b/LENR.ipynb
@@ -405,7 +405,13 @@
     "\n",
     "# Sanity: boundary of boundary\n",
     "bdb = (B1 @ B2).toarray()\n",
-    "print(\"||B1·B2||_∞ =\", np.max(np.abs(bdb)))  # should be 0.0"
+    "print(\"||B1·B2||_∞ =\", np.max(np.abs(bdb)))  # should be 0.0\n",
+    "\n",
+    "# Export edge index/counts for downstream cells\n",
+    "edge_idx = dict(edge_id)\n",
+    "n_edges = len(edge_idx)\n",
+    "n_faces = len(face_id)\n",
+    "print(f\"Backbone sizes: |E|={n_edges} |F|={n_faces}\")"
    ],
    "metadata": {
     "colab": {


### PR DESCRIPTION
## Summary
- export the DEC backbone edge index and edge/face counts so downstream steppers can use them
- log the backbone edge and face totals after building the operators for easier auditing

## Testing
- python - <<'PY' ...> (fails: ModuleNotFoundError: No module named 'numpy')

------
https://chatgpt.com/codex/tasks/task_e_68cbb98a6744832da68843cc252fc5c6