### PR TITLE
Add Colab badge to LENR_fixed notebook

### DIFF
--- a/LENR_fixed.ipynb
+++ b/LENR_fixed.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/Berigny/AI-Entrainment-Protocol/blob/main/LENR_fixed.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Low Energy Nuclear (LENR) Cycles Model (Fixed)\n",


### PR DESCRIPTION
## Summary
- add an "Open in Colab" badge to the top of `LENR_fixed.ipynb` so it can be launched directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbdfd75dd8832d9e34e1cbd2cdca0d